### PR TITLE
Cuda

### DIFF
--- a/language-id.el
+++ b/language-id.el
@@ -107,6 +107,10 @@
     ("CSS"
      css-mode
      (web-mode (web-mode-content-type "css") (web-mode-engine "none")))
+    ("Cuda"
+     cuda-mode
+     (or (language-id--file-name-extension ".cu")
+         (language-id--file-name-extension ".cuh")))
     ("D" d-mode)
     ("Dart" dart-mode)
     ("Dhall" dhall-mode)
@@ -114,7 +118,6 @@
     ("Elixir" elixir-mode)
     ("Elm" elm-mode)
     ("Emacs Lisp" emacs-lisp-mode)
-    ("F#" fsharp-mode)
     ("Fish" fish-mode)
     ("GLSL" glsl-mode)
     ("Go" go-mode)

--- a/language-id.el
+++ b/language-id.el
@@ -114,6 +114,7 @@
     ("Elixir" elixir-mode)
     ("Elm" elm-mode)
     ("Emacs Lisp" emacs-lisp-mode)
+    ("F#" fsharp-mode)
     ("Fish" fish-mode)
     ("GLSL" glsl-mode)
     ("Go" go-mode)

--- a/language-id.el
+++ b/language-id.el
@@ -36,6 +36,16 @@
 
     ;;; Definitions that need special attention to precedence order.
 
+    ;; It is not uncommon for C++ mode to be used when writing Cuda.
+    ;; In this case, the only way to correctly identify Cuda is by looking at
+    ;; the extension
+    ("Cuda"
+     c++-mode
+     (language-id--file-name-extension ".cu"))
+    ("Cuda"
+     c++-mode
+     (language-id--file-name-extension ".cuh"))
+
     ;; json-mode is derived from javascript-mode.
     ("JSON"
      json-mode
@@ -107,10 +117,7 @@
     ("CSS"
      css-mode
      (web-mode (web-mode-content-type "css") (web-mode-engine "none")))
-    ("Cuda"
-     cuda-mode
-     (or (language-id--file-name-extension ".cu")
-         (language-id--file-name-extension ".cuh")))
+    ("Cuda" cuda-mode)
     ("D" d-mode)
     ("Dart" dart-mode)
     ("Dhall" dhall-mode)


### PR DESCRIPTION
Correctly identify Cuda. It is not uncommon to see Cuda written in C++ mode, so in addition to looking for cuda-mode, do an early check for the file extension