### PR TITLE
Identify Fortran

### DIFF
--- a/language-id.el
+++ b/language-id.el
@@ -115,6 +115,8 @@
     ("Elm" elm-mode)
     ("Emacs Lisp" emacs-lisp-mode)
     ("Fish" fish-mode)
+    ("Fortran" fortran-mode)
+    ("Fortran Free Form" f90-mode)
     ("GLSL" glsl-mode)
     ("Go" go-mode)
     ("GraphQL" graphql-mode)


### PR DESCRIPTION
Correctly identify Fortran. The Github linguist list uses "Fortran Free Form" to describe the Fortran dialects often referred to as Fortran 90. I have stuck with Github linguist but I can change it if you prefer