### PR TITLE
Add Erlang

### DIFF
--- a/language-id.el
+++ b/language-id.el
@@ -148,6 +148,7 @@
     ("Elixir" elixir-mode)
     ("Elm" elm-mode)
     ("Emacs Lisp" emacs-lisp-mode)
+    ("Erlang" erlang-mode)
     ("F#" fsharp-mode)
     ("Fish" fish-mode)
     ("Fortran" fortran-mode)


### PR DESCRIPTION
Hi,

I'm going to create a PR to `emacs-format-all-the-code` to add an Erlang formatter. So I want to add an entry for Erlang here too.