### PR TITLE
add rescript-mode

### DIFF
--- a/language-id.el
+++ b/language-id.el
@@ -106,7 +106,6 @@
       (web-mode-engine "none")
       (language-id--file-name-extension ".ts")))
 
-    ("ReScript" rescript-mode)
     ;; ReScript needs to come before Reason because in reason-mode
     ;; we can tell them apart by file name extension only.
     ("ReScript"
@@ -115,6 +114,7 @@
     ("ReScript"
      (reason-mode
       (language-id--file-name-extension ".resi")))
+    ("ReScript" rescript-mode)
     ("Reason" reason-mode)
 
     ;; vue-html-mode is derived from html-mode.

--- a/language-id.el
+++ b/language-id.el
@@ -106,6 +106,7 @@
       (web-mode-engine "none")
       (language-id--file-name-extension ".ts")))
 
+    ("ReScript" rescript-mode)
     ;; ReScript needs to come before Reason because in reason-mode
     ;; we can tell them apart by file name extension only.
     ("ReScript"


### PR DESCRIPTION
So there's this new mode[1] for ReScript which I found necessary since its syntax has departured from Reason quite significantly[2]. I understand that it's not endorsed directly by ReScript at the moment[3], but the endorsed `reason-mode` will still work so far as `rescript-mode` is not installed so I think we're fine

[1]: https://github.com/jjlee/rescript-mode
[2]: https://rescript-lang.org/docs/manual/v8.0.0/migrate-from-bucklescript-reason#difference-with-old-reason
[3]: https://archive.ph/RbpyZ