### PR TITLE
Autoload language-id-buffer

### DIFF
--- a/language-id.el
+++ b/language-id.el
@@ -269,6 +269,7 @@
                        (if (boundp symbol) (symbol-value symbol) nil))))
             variables)))))
 
+;;;###autoload
 (defun language-id-buffer ()
   "Get GitHub Linguist language name for current buffer.
 


### PR DESCRIPTION
so it can be used without having to require first.